### PR TITLE
Edit to be made when setting up commudle Locally

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,8 +60,9 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
-
-  config.active_storage.service = :amazon
+  
+  #when setting up the project locally 
+  config.active_storage.service = :local
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -5,7 +5,7 @@ test:
   root: <%= Rails.root.join("tmp/storage") %>
   
   
-\\ When Building Locally
+\\ When Building Locally (rails db:migrate may give errors) 
 
 local:
   service: Disk

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,3 +1,18 @@
+\\For testing Purpose
+
+test:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>
+  
+  
+\\ When Building Locally
+
+local:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>
+  
+
+\\ When using AWS :
 amazon:
   service: S3
   access_key_id: <%= ENV['KOMMUNITY_APP_S3_ACCESS_ID'] %>


### PR DESCRIPTION
I have made following edits while setting up Commudle in Local Machine : 

1.) Go to ./config/storage.yml and add the following codes :  

`test:
  service: Disk
  root: <%= Rails.root.join("tmp/storage") %>


local:
  service: Disk
  root: <%= Rails.root.join("storage") %>`

and

2.)  If you are using local machine instead amazone aws just edit the following code (if not already done ) in ./config/environments/development.rb : 
`config.active_storage.service = :local` 

instead of : 
`config.active_storage.service = :amazon` 

