### PR TITLE
Fix License Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Summing it all up, we're looking at creating more and more projects soon, this b
 
 ---
 
-[License](project-setup.md)
+[License](LICENSE.md)
 
 
 


### PR DESCRIPTION
The license link on the docs links to project setuprather than license file

Fixed the link for that